### PR TITLE
Fix non-sef endpoint url generation

### DIFF
--- a/templates/wc-endpoint-wallet.php
+++ b/templates/wc-endpoint-wallet.php
@@ -23,9 +23,9 @@ global $wp;
     <div class="woo-wallet-sidebar">
         <h3 class="woo-wallet-sidebar-heading"><a href="<?php echo is_account_page() ? esc_url(wc_get_account_endpoint_url(get_option('woocommerce_woo_wallet_endpoint', 'woo-wallet'))) : get_permalink(); ?>"><?php _e('My Wallet', 'woo-wallet'); ?></a></h3>
         <ul>
-            <li class="card"><a href="<?php echo is_account_page() ? esc_url(wc_get_account_endpoint_url(get_option('woocommerce_woo_wallet_endpoint', 'woo-wallet')) . 'add/') : '?wallet_action=add'; ?>" ><span class="dashicons dashicons-plus-alt"></span><p><?php _e('Wallet topup', 'woo-wallet'); ?></p></a></li>
+            <li class="card"><a href="<?php echo is_account_page() ? esc_url(wc_get_endpoint_url( get_option('woocommerce_woo_wallet_endpoint', 'woo-wallet'), 'add', wc_get_page_permalink( 'myaccount' ))) : '?wallet_action=add'; ?>" ><span class="dashicons dashicons-plus-alt"></span><p><?php _e('Wallet topup', 'woo-wallet'); ?></p></a></li>
             <?php if (apply_filters('woo_wallet_is_enable_transfer', 'on' === woo_wallet()->settings_api->get_option('is_enable_wallet_transfer', '_wallet_settings_general', 'on'))) : ?>
-                <li class="card"><a href="<?php echo is_account_page() ? esc_url(wc_get_account_endpoint_url(get_option('woocommerce_woo_wallet_endpoint', 'woo-wallet')) . 'transfer/') : '?wallet_action=transfer'; ?>" ><span class="dashicons dashicons-randomize"></span><p><?php _e('Wallet transfer', 'woo-wallet'); ?></p></a></li>
+                <li class="card"><a href="<?php echo is_account_page() ? esc_url(wc_get_endpoint_url( get_option('woocommerce_woo_wallet_endpoint', 'woo-wallet'), 'transfer', wc_get_page_permalink( 'myaccount' ))) : '?wallet_action=transfer'; ?>" ><span class="dashicons dashicons-randomize"></span><p><?php _e('Wallet transfer', 'woo-wallet'); ?></p></a></li>
             <?php endif; ?>
             <li class="card"><a href="<?php echo is_account_page() ? esc_url(wc_get_account_endpoint_url(get_option('woocommerce_woo_wallet_transactions_endpoint', 'woo-wallet-transactions'))) : '?wallet_action=view_transactions'; ?>"><span class="dashicons dashicons-list-view"></span><p><?php _e('Transactions', 'woo-wallet'); ?></p></a></li>
         </ul>


### PR DESCRIPTION
Your plugin does not work correctly with disabled SEF links.
Url to "add" page is generated like http://site.com/?page_id=5&woo-walletadd/

Use `wc_get_endpoint_url` to pass a query var and generate correct url (both sef and non-sef)