### PR TITLE
Fix typos in localization strings

### DIFF
--- a/includes/class-woo-wallet-payment-method.php
+++ b/includes/class-woo-wallet-payment-method.php
@@ -59,14 +59,14 @@ class Woo_Gateway_Wallet_payment extends WC_Payment_Gateway {
             'title' => array(
                 'title' => __('Title', 'woo-wallet'),
                 'type' => 'text',
-                'description' => __('Payment method description that the customer will see on your checkout.', 'woo-wallet'),
+                'description' => __('This controls the title which the user sees during checkout.', 'woo-wallet'),
                 'default' => __('Wallet payment', 'woo-wallet'),
                 'desc_tip' => true,
             ),
             'description' => array(
                 'title' => __('Description', 'woo-wallet'),
                 'type' => 'textarea',
-                'description' => __('Payment method description that the customer will see on your website.', 'woo-wallet'),
+                'description' => __('Payment method description that the customer will see on your checkout.', 'woo-wallet'),
                 'default' => __('Pay with wallet.', 'woo-wallet'),
                 'desc_tip' => true,
             ),

--- a/includes/class-woo-wallet-settings.php
+++ b/includes/class-woo-wallet-settings.php
@@ -107,7 +107,7 @@ if (!class_exists('Woo_Wallet_Settings')):
                     array(
                         'name' => 'min_topup_amount',
                         'label' => __('Minimum Topup Amount', 'woo-wallet'),
-                        'desc' => __('The minimum amount needed for wallet top up.', 'woo-wallet'),
+                        'desc' => __('The minimum amount needed for wallet top up', 'woo-wallet'),
                         'type' => 'number',
                     ),
                     array(

--- a/includes/class-woo-wallet.php
+++ b/includes/class-woo-wallet.php
@@ -266,7 +266,7 @@ final class WooWallet {
      */
     public function admin_notices() {
         echo '<div class="error"><p>';
-        _e('WooCommerce Wallet plugin requires <a href="http://wordpress.org/extend/plugins/woocommerce/">WooCommerce</a> plugins to be active!', 'woo-wallet');
+        _e('WooCommerce Wallet plugin requires <a href="https://wordpress.org/plugins/woocommerce/">WooCommerce</a> plugins to be active!', 'woo-wallet');
         echo '</p></div>';
     }
 

--- a/templates/emails/plain/user-new-transaction.php
+++ b/templates/emails/plain/user-new-transaction.php
@@ -21,10 +21,10 @@ $remaining = woo_wallet()->wallet->get_wallet_balance($user->ID, 'edit');
 echo "= " . $email_heading . " =\n\n";
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 if ($type == 'credit') { 
-    echo __('Thank you for using your wallet.', 'woo-wallet')." {$currency} {$amount} ". __('has been credited to your wallet.', 'woo-wallet'). __('Current wallet balance is', 'woo-wallet')." {$currency} {$remaining}";
+    echo __('Thank you for using your wallet.', 'woo-wallet')." {$currency} {$amount} ". __('has been credited to your wallet.', 'woo-wallet'). " " . __('Current wallet balance is', 'woo-wallet')." {$currency} {$remaining}";
 }
 if ($type == 'debit') {
-    echo __('Thank you for using your wallet.', 'woo-wallet')." {$currency} {$amount} ". __('has been debited to your wallet.', 'woo-wallet'). __(' Current wallet balance is', 'woo-wallet')." {$currency} {$remaining}";
+    echo __('Thank you for using your wallet.', 'woo-wallet')." {$currency} {$amount} ". __('has been debited from your wallet.', 'woo-wallet'). " " . __('Current wallet balance is', 'woo-wallet')." {$currency} {$remaining}";
 }
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/templates/emails/user-new-transaction.php
+++ b/templates/emails/user-new-transaction.php
@@ -22,10 +22,10 @@ if (!defined('ABSPATH')) {
 do_action('woocommerce_email_header', $email_heading, $email);
 ?>
 <?php if ($type == 'credit') { ?>
-<p><?php _e("Thank you for using your wallet. ", 'woo-wallet'); ?><?php echo wc_price($amount); ?> <?php _e( ' has been credited to your wallet.', 'woo-wallet'); ?> <?php _e('Current wallet balance is ', 'woo-wallet'); ?><?php echo woo_wallet()->wallet->get_wallet_balance($user->ID); ?></p>
+<p><?php _e("Thank you for using your wallet.", 'woo-wallet'); ?> <?php echo wc_price($amount); ?> <?php _e( 'has been credited to your wallet.', 'woo-wallet'); ?> <?php _e('Current wallet balance is', 'woo-wallet'); ?> <?php echo woo_wallet()->wallet->get_wallet_balance($user->ID); ?></p>
 <?php } ?>
 <?php if ($type == 'debit') { ?>
-    <p><?php _e("Thank you for using your wallet. ", 'woo-wallet'); ?><?php echo wc_price($amount); ?> <?php _e( ' has been debited from your wallet.', 'woo-wallet'); ?> <?php _e('Current wallet balance is ', 'woo-wallet'); ?><?php echo woo_wallet()->wallet->get_wallet_balance($user->ID); ?></p>
+    <p><?php _e("Thank you for using your wallet.", 'woo-wallet'); ?> <?php echo wc_price($amount); ?> <?php _e( 'has been debited from your wallet.', 'woo-wallet'); ?> <?php _e('Current wallet balance is', 'woo-wallet'); ?> <?php echo woo_wallet()->wallet->get_wallet_balance($user->ID); ?></p>
 <?php } ?>
 <?php
 /**


### PR DESCRIPTION
Some minor typos I found in your plugin when translating. Unfortunately, I can't figure out how to rebuild `pot` file..