### PR TITLE
add "Top up user wallet on order status" option, for credit purchase

### DIFF
--- a/includes/class-woo-wallet-payment-method.php
+++ b/includes/class-woo-wallet-payment-method.php
@@ -129,10 +129,12 @@ if(class_exists( 'WC_Payment_Gateway' )){
             if ( $wallet_response) {
                 $order->payment_complete( $wallet_response);
 				
-				$wallet_payment_method_order_status = woo_wallet()->settings_api->get_option('wallet_payment_method_order_status', '_wallet_settings_general', 'completed');
-				$order->update_status($wallet_payment_method_order_status,
-            __('Order status set to ' . $wallet_payment_method_order_status . ' by Woo Wallet',
-                'fsww'));
+				$wallet_payment_method_order_status = woo_wallet()->settings_api->get_option('wallet_payment_method_order_status', '_wallet_settings_general', 'not-set');
+				if ( $wallet_payment_method_order_status != 'not-set'){
+					$order->update_status($wallet_payment_method_order_status,
+					__('Order status set to ' . $wallet_payment_method_order_status . ' by Woo Wallet',
+					'fsww'));
+				}
 				
                 do_action( 'woo_wallet_payment_processed', $order_id, $wallet_response);
             }

--- a/includes/class-woo-wallet-payment-method.php
+++ b/includes/class-woo-wallet-payment-method.php
@@ -128,6 +128,12 @@ if(class_exists( 'WC_Payment_Gateway' )){
 
             if ( $wallet_response) {
                 $order->payment_complete( $wallet_response);
+				
+				$wallet_payment_method_order_status = woo_wallet()->settings_api->get_option('wallet_payment_method_order_status', '_wallet_settings_general', 'completed');
+				$order->update_status($wallet_payment_method_order_status,
+            __('Order status set to ' . $wallet_payment_method_order_status . ' by Woo Wallet',
+                'fsww'));
+				
                 do_action( 'woo_wallet_payment_processed', $order_id, $wallet_response);
             }
 

--- a/includes/class-woo-wallet-settings.php
+++ b/includes/class-woo-wallet-settings.php
@@ -131,9 +131,9 @@ if ( ! class_exists( 'Woo_Wallet_Settings' ) ):
                         'step' => '0.01'
                     ),
 					array(
-                        'name' => 'top_up__wallet_order_status',
+                        'name' => 'top_up_wallet_order_status',
                         'label' => __( 'Top up user wallet on order status:', 'woo-wallet' ),
-                        'desc' => __( 'Select transfer charge type percentage or fixed', 'woo-wallet' ),
+                        'desc' => __( 'Select status for topup wallet order', 'woo-wallet' ),
                         'type' => 'select',
                         'options' => array( 'Processing' , 'Completed',  'Processing & Completed'),
                         'size' => 'regular-text wc-enhanced-select'

--- a/includes/class-woo-wallet-settings.php
+++ b/includes/class-woo-wallet-settings.php
@@ -137,6 +137,14 @@ if ( ! class_exists( 'Woo_Wallet_Settings' ) ):
                         'type' => 'select',
                         'options' => array( 'Processing' , 'Completed',  'Processing & Completed'),
                         'size' => 'regular-text wc-enhanced-select'
+                    ),
+					array(
+                        'name' => 'wallet_payment_method_order_status',
+                        'label' => __( 'Payment complete on order status:', 'woo-wallet' ),
+                        'desc' => __( 'Select status for order that paid with wallet gateway', 'woo-wallet' ),
+                        'type' => 'select',
+                        'options' => array( 'completed', 'processing'),
+                        'size' => 'regular-text wc-enhanced-select'
                     )
 					), $this->wp_menu_locations(), array(
                     array(

--- a/includes/class-woo-wallet-settings.php
+++ b/includes/class-woo-wallet-settings.php
@@ -132,18 +132,18 @@ if ( ! class_exists( 'Woo_Wallet_Settings' ) ):
                     ),
 					array(
                         'name' => 'top_up_wallet_order_status',
-                        'label' => __( 'Top up user wallet on order status:', 'woo-wallet' ),
-                        'desc' => __( 'Select status for topup wallet order', 'woo-wallet' ),
+                        'label' => __( 'Top up wallet on order status:', 'woo-wallet' ),
+                        'desc' => __( 'top up the wallet when order status is', 'woo-wallet' ),
                         'type' => 'select',
-                        'options' => array( 'Processing' , 'Completed',  'Processing & Completed'),
+                        'options' => array( 'processing' => __( 'Processing', 'woo-wallet' ), 'completed' => __( 'Completed', 'woo-wallet' ) ),
                         'size' => 'regular-text wc-enhanced-select'
                     ),
 					array(
                         'name' => 'wallet_payment_method_order_status',
-                        'label' => __( 'Payment complete on order status:', 'woo-wallet' ),
+                        'label' => __( 'Wallet payment order status:', 'woo-wallet' ),
                         'desc' => __( 'Select status for order that paid with wallet gateway', 'woo-wallet' ),
                         'type' => 'select',
-                        'options' => array( 'completed', 'processing'),
+                        'options' => array( 'not-set' => __( 'Define by woocommerce', 'woo-wallet' ), 'completed' => __( 'Completed', 'woo-wallet' ), 'processing' => __( 'Processing', 'woo-wallet' ) ),
                         'size' => 'regular-text wc-enhanced-select'
                     )
 					), $this->wp_menu_locations(), array(

--- a/includes/class-woo-wallet-settings.php
+++ b/includes/class-woo-wallet-settings.php
@@ -129,7 +129,16 @@ if ( ! class_exists( 'Woo_Wallet_Settings' ) ):
                         'desc' => __( 'The maximum amount needed for wallet top up', 'woo-wallet' ),
                         'type' => 'number',
                         'step' => '0.01'
-                    ) ), $this->wp_menu_locations(), array(
+                    ),
+					array(
+                        'name' => 'top_up__wallet_order_status',
+                        'label' => __( 'Top up user wallet on order status:', 'woo-wallet' ),
+                        'desc' => __( 'Select transfer charge type percentage or fixed', 'woo-wallet' ),
+                        'type' => 'select',
+                        'options' => array( 'Processing' , 'Completed',  'Processing & Completed'),
+                        'size' => 'regular-text wc-enhanced-select'
+                    )
+					), $this->wp_menu_locations(), array(
                     array(
                         'name' => 'is_auto_deduct_for_partial_payment',
                         'label' => __( 'Auto deduct wallet balance for partial payment', 'woo-wallet' ),

--- a/includes/class-woo-wallet-wallet.php
+++ b/includes/class-woo-wallet-wallet.php
@@ -101,6 +101,13 @@ if ( ! class_exists( 'Woo_Wallet_Wallet' ) ) {
             if ( ! is_wallet_rechargeable_order( $order ) ) {
                 return;
             }
+			$top_up__wallet_order_status = woo_wallet()->settings_api->get_option('top_up__wallet_order_status', '_wallet_settings_general');
+            if ( $order->get_status() == 'completed' && $top_up__wallet_order_status == 0 ){
+                return;
+            }
+            if ( $order->get_status() == 'processing' && $top_up__wallet_order_status == 1 ){
+                return;
+            }
             $recharge_amount = apply_filters( 'woo_wallet_credit_purchase_amount', $order->get_subtotal( 'edit' ), $order_id );
             if ( 'on' === woo_wallet()->settings_api->get_option( 'is_enable_gateway_charge', '_wallet_settings_credit', 'off' ) ) {
                 $charge_amount = woo_wallet()->settings_api->get_option( $order->get_payment_method(), '_wallet_settings_credit', 0 );

--- a/includes/class-woo-wallet-wallet.php
+++ b/includes/class-woo-wallet-wallet.php
@@ -101,11 +101,11 @@ if ( ! class_exists( 'Woo_Wallet_Wallet' ) ) {
             if ( ! is_wallet_rechargeable_order( $order ) ) {
                 return;
             }
-			$top_up__wallet_order_status = woo_wallet()->settings_api->get_option('top_up__wallet_order_status', '_wallet_settings_general');
-            if ( $order->get_status() == 'completed' && $top_up__wallet_order_status == 0 ){
+			$top_up_wallet_order_status = woo_wallet()->settings_api->get_option('top_up_wallet_order_status', '_wallet_settings_general');
+            if ( $order->get_status() == 'completed' && $top_up_wallet_order_status == 0 ){
                 return;
             }
-            if ( $order->get_status() == 'processing' && $top_up__wallet_order_status == 1 ){
+            if ( $order->get_status() == 'processing' && $top_up_wallet_order_status == 1 ){
                 return;
             }
             $recharge_amount = apply_filters( 'woo_wallet_credit_purchase_amount', $order->get_subtotal( 'edit' ), $order_id );

--- a/includes/class-woo-wallet-wallet.php
+++ b/includes/class-woo-wallet-wallet.php
@@ -101,11 +101,8 @@ if ( ! class_exists( 'Woo_Wallet_Wallet' ) ) {
             if ( ! is_wallet_rechargeable_order( $order ) ) {
                 return;
             }
-			$top_up_wallet_order_status = woo_wallet()->settings_api->get_option('top_up_wallet_order_status', '_wallet_settings_general');
-            if ( $order->get_status() == 'completed' && $top_up_wallet_order_status == 0 ){
-                return;
-            }
-            if ( $order->get_status() == 'processing' && $top_up_wallet_order_status == 1 ){
+			$top_up_wallet_order_status = woo_wallet()->settings_api->get_option('top_up_wallet_order_status', '_wallet_settings_general', 'processing');
+      		if ( $order->get_status() != $top_up_wallet_order_status ){
                 return;
             }
             $recharge_amount = apply_filters( 'woo_wallet_credit_purchase_amount', $order->get_subtotal( 'edit' ), $order_id );


### PR DESCRIPTION
when my customers added funds to their wallet, immediately after purchase, the fund added to their wallet.
but i needed to check the payments first, and when i complete the order, they get their money in their wallet.
but by default when order was in 'processing' or 'completed' fund added automatically.

but now you have 3 option to select, 
 'processing' = credit_purchase complete only if order is in processing status
 'completed' = credit_purchase complete only if order is in completed status
 'processing completed' = credit_purchase complete only if order is in processing or completed status