### PR TITLE
fix(partial-payment): exclude locked wallets from auto-deduct discounts

### DIFF
--- a/includes/class-woo-wallet-ajax.php
+++ b/includes/class-woo-wallet-ajax.php
@@ -377,6 +377,10 @@ if ( ! class_exists( 'Woo_Wallet_Ajax' ) ) {
 		 * @return void
 		 */
 		public function woo_wallet_partial_payment_update_session() {
+			if ( is_wallet_account_locked() ) {
+				update_wallet_partial_payment_session();
+				wp_die();
+			}
 			if ( isset( $_POST['checked'] ) && 'true' === $_POST['checked'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 				update_wallet_partial_payment_session( woo_wallet()->wallet->get_wallet_balance( get_current_user_id(), 'edit' ) );
 			} else {

--- a/includes/class-woo-wallet-partial-payment-blocks.php
+++ b/includes/class-woo-wallet-partial-payment-blocks.php
@@ -93,11 +93,11 @@ class WOO_Wallet_Partial_Payment_Blocks implements IntegrationInterface {
 	public function get_script_data() {
 		$is_enable  = false;
 		$cart_total = get_woowallet_cart_total();
-		if ( 'on' === woo_wallet()->settings_api->get_option( 'is_enable_partial_payment', '_wallet_settings_general', 'on' ) && ! is_wallet_rechargeable_cart() && is_user_logged_in() && 'on' !== woo_wallet()->settings_api->get_option( 'is_auto_deduct_for_partial_payment', '_wallet_settings_general' ) && woo_wallet()->wallet->get_wallet_balance( get_current_user_id(), 'edit' ) > 0 && $cart_total > woo_wallet()->wallet->get_wallet_balance( get_current_user_id(), 'edit' ) ) {
+		if ( 'on' === woo_wallet()->settings_api->get_option( 'is_enable_partial_payment', '_wallet_settings_general', 'on' ) && ! is_wallet_rechargeable_cart() && is_user_logged_in() && ! is_wallet_account_locked() && 'on' !== woo_wallet()->settings_api->get_option( 'is_auto_deduct_for_partial_payment', '_wallet_settings_general' ) && woo_wallet()->wallet->get_wallet_balance( get_current_user_id(), 'edit' ) > 0 && $cart_total > woo_wallet()->wallet->get_wallet_balance( get_current_user_id(), 'edit' ) ) {
 			$is_enable = true;
 		}
 		$data = array(
-			'active'                 => apply_filters( 'is_enable_wallet_partial_payment', $is_enable ),
+			'active'                 => is_wallet_account_locked() ? false : (bool) apply_filters( 'is_enable_wallet_partial_payment', $is_enable ),
 			'balance'                => woo_wallet()->wallet->get_wallet_balance( get_current_user_id(), 'edit' ),
 			'partial_payment_amount' => ! is_null( wc()->session ) && woo_wallet()->wallet->get_wallet_balance( get_current_user_id(), 'edit' ) >= wc()->session->get( 'partial_payment_amount', 0 ) ? wc()->session->get( 'partial_payment_amount', 0 ) : woo_wallet()->wallet->get_wallet_balance( get_current_user_id(), 'edit' ),
 			'max_amount'             => woo_wallet_get_partial_payment_max_amount(),

--- a/includes/class-woo-wallet-wallet.php
+++ b/includes/class-woo-wallet-wallet.php
@@ -643,9 +643,12 @@ if ( ! class_exists( 'Woo_Wallet_Wallet' ) ) {
 					}
 					do_action( 'woo_wallet_partial_payment_completed', $transaction_id, $locked_order );
 				} else {
-					// Insufficient balance (e.g. spent before payment cleared). Hold the
-					// order for review rather than overdrafting the wallet.
-					$locked_order->update_status( 'on-hold', __( 'Wallet partial payment could not be debited (insufficient balance). Held for review. ', 'woo-wallet' ) );
+					// Debit refused (locked wallet, or balance spent before payment
+					// cleared). Hold the order for review rather than undercharging.
+					$fail_note = is_wallet_account_locked( $locked_order->get_customer_id() )
+						? __( 'Wallet partial payment could not be debited (wallet is locked). Held for review. ', 'woo-wallet' )
+						: __( 'Wallet partial payment could not be debited (insufficient balance). Held for review. ', 'woo-wallet' );
+					$locked_order->update_status( 'on-hold', $fail_note );
 					do_action( 'woo_wallet_partial_payment_debit_failed', $locked_order, $partial_payment_amount );
 				}
 			} finally {

--- a/includes/class-woo-wallet.php
+++ b/includes/class-woo-wallet.php
@@ -518,14 +518,20 @@ final class Woo_Wallet {
 			array(
 				'namespace' => 'apply-partial-payment',
 				'callback'  => function ( $data ) {
-					if ( ! is_null( wc()->session ) ) {
-						$amount = isset( $data['amount'] ) ? (float) $data['amount'] : 0;
-						$max    = woo_wallet_get_partial_payment_max_amount();
-						if ( $max > 0 && $amount > $max ) {
-							$amount = $max;
-						}
-						wc()->session->set( 'partial_payment_amount', $amount );
+					if ( is_null( wc()->session ) ) {
+						return;
 					}
+					// Locked wallets cannot be spent — clear any prior opt-in amount.
+					if ( is_wallet_account_locked() ) {
+						wc()->session->set( 'partial_payment_amount', 0 );
+						return;
+					}
+					$amount = isset( $data['amount'] ) ? (float) $data['amount'] : 0;
+					$max    = woo_wallet_get_partial_payment_max_amount();
+					if ( $max > 0 && $amount > $max ) {
+						$amount = $max;
+					}
+					wc()->session->set( 'partial_payment_amount', $amount );
 				},
 			)
 		);

--- a/includes/helper/woo-wallet-util.php
+++ b/includes/helper/woo-wallet-util.php
@@ -252,10 +252,23 @@ if ( ! function_exists( 'is_enable_wallet_partial_payment' ) ) {
 	function is_enable_wallet_partial_payment() {
 		$is_enable  = false;
 		$cart_total = get_woowallet_cart_total();
-		if ( ! is_wallet_rechargeable_cart() && is_user_logged_in() && ( ( ! is_null( wc()->session ) && wc()->session->get( 'partial_payment_amount', false ) ) || 'on' === woo_wallet()->settings_api->get_option( 'is_auto_deduct_for_partial_payment', '_wallet_settings_general' ) ) && $cart_total >= apply_filters( 'woo_wallet_partial_payment_amount', woo_wallet()->wallet->get_wallet_balance( get_current_user_id(), 'edit' ) ) ) {
+		if ( ! is_wallet_rechargeable_cart() && is_user_logged_in() && ! is_wallet_account_locked() && ( ( ! is_null( wc()->session ) && wc()->session->get( 'partial_payment_amount', false ) ) || 'on' === woo_wallet()->settings_api->get_option( 'is_auto_deduct_for_partial_payment', '_wallet_settings_general' ) ) && $cart_total >= apply_filters( 'woo_wallet_partial_payment_amount', woo_wallet()->wallet->get_wallet_balance( get_current_user_id(), 'edit' ) ) ) {
 			$is_enable = true;
 		}
-		return apply_filters( 'is_enable_wallet_partial_payment', $is_enable );
+		/**
+		 * Filters whether wallet partial payment is enabled for the current cart.
+		 *
+		 * Locked wallets must never contribute a checkout discount: the ledger
+		 * refuses debit while locked, so allowing the fee here would undercharge
+		 * the order without withdrawing funds.
+		 *
+		 * @param bool $is_enable Whether partial payment is enabled.
+		 */
+		$is_enable = (bool) apply_filters( 'is_enable_wallet_partial_payment', $is_enable );
+		if ( is_wallet_account_locked() ) {
+			return false;
+		}
+		return $is_enable;
 	}
 }
 

--- a/tests/test-partial-payment-locked-wallet.php
+++ b/tests/test-partial-payment-locked-wallet.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Locked-wallet partial payment regression tests.
+ *
+ * A locked wallet must never produce a "Via wallet" checkout discount. The
+ * ledger already refuses debit while locked; if the cart fee still applies,
+ * the customer is undercharged without funds being withdrawn.
+ *
+ * @package WooWallet\Tests
+ */
+
+/**
+ * @covers ::is_enable_wallet_partial_payment
+ * @covers Woo_Wallet_Wallet::debit_partial_payment_for_order
+ */
+class Test_Partial_Payment_Locked_Wallet extends WP_UnitTestCase {
+
+	/**
+	 * Customer id.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Fresh customer per test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $this->user_id );
+	}
+
+	/**
+	 * Persist a value into the general settings section.
+	 *
+	 * @param string $key   option key.
+	 * @param mixed  $value value.
+	 */
+	private function set_setting( $key, $value ) {
+		$opt         = (array) get_option( '_wallet_settings_general', array() );
+		$opt[ $key ] = $value;
+		update_option( '_wallet_settings_general', $opt );
+	}
+
+	/**
+	 * Wallet balance as float.
+	 *
+	 * @return float
+	 */
+	private function balance() {
+		return (float) woo_wallet()->wallet->get_wallet_balance( $this->user_id, 'edit' );
+	}
+
+	/**
+	 * Simulate a cart whose total exceeds the wallet balance (partial-payment case).
+	 *
+	 * @param float $total cart total.
+	 */
+	private function stub_cart_total( $total ) {
+		add_filter(
+			'woowallet_cart_total',
+			static function () use ( $total ) {
+				return $total;
+			}
+		);
+	}
+
+	/**
+	 * Auto-deduct + locked wallet must not enable partial payment (bug report).
+	 */
+	public function test_auto_deduct_disabled_when_wallet_locked() {
+		woo_wallet()->wallet->credit( $this->user_id, 700, 'seed' );
+		update_user_meta( $this->user_id, '_is_wallet_locked', true );
+
+		$this->set_setting( 'is_enable_partial_payment', 'on' );
+		$this->set_setting( 'is_auto_deduct_for_partial_payment', 'on' );
+		$this->stub_cart_total( 900 );
+
+		$this->assertTrue( is_wallet_account_locked( $this->user_id ) );
+		$this->assertFalse( is_enable_wallet_partial_payment() );
+	}
+
+	/**
+	 * Same setup with an unlocked wallet still enables auto-deduct partial payment.
+	 */
+	public function test_auto_deduct_enabled_when_wallet_unlocked() {
+		woo_wallet()->wallet->credit( $this->user_id, 700, 'seed' );
+
+		$this->set_setting( 'is_enable_partial_payment', 'on' );
+		$this->set_setting( 'is_auto_deduct_for_partial_payment', 'on' );
+		$this->stub_cart_total( 900 );
+
+		$this->assertFalse( is_wallet_account_locked( $this->user_id ) );
+		$this->assertTrue( is_enable_wallet_partial_payment() );
+	}
+
+	/**
+	 * Filters must not re-enable partial payment for a locked wallet.
+	 */
+	public function test_lock_overrides_enable_filter() {
+		woo_wallet()->wallet->credit( $this->user_id, 700, 'seed' );
+		update_user_meta( $this->user_id, '_is_wallet_locked', true );
+
+		$this->set_setting( 'is_auto_deduct_for_partial_payment', 'on' );
+		$this->stub_cart_total( 900 );
+
+		add_filter( 'is_enable_wallet_partial_payment', '__return_true' );
+
+		$this->assertFalse( is_enable_wallet_partial_payment() );
+	}
+
+	/**
+	 * If a partial-payment fee somehow reaches order processing while locked,
+	 * the debit fails, balance is unchanged, and the order is held.
+	 */
+	public function test_partial_debit_fails_cleanly_when_locked() {
+		woo_wallet()->wallet->credit( $this->user_id, 700, 'seed' );
+		update_user_meta( $this->user_id, '_is_wallet_locked', true );
+
+		$order = new WC_Order();
+		$order->set_customer_id( $this->user_id );
+		$order->set_currency( get_woocommerce_currency() );
+		$fee = new WC_Order_Item_Fee();
+		$fee->set_name( 'Via wallet' );
+		$fee->set_total( -700 );
+		$fee->set_total_tax( 0 );
+		$order->add_item( $fee );
+		$order->save();
+
+		woo_wallet()->wallet->woocommerce_order_processed( $order );
+
+		$this->assertEquals( 700.0, $this->balance() );
+		$fresh = wc_get_order( $order->get_id() );
+		$this->assertEmpty( $fresh->get_meta( '_partial_pay_through_wallet_compleate' ) );
+		$this->assertEquals( 'on-hold', $fresh->get_status() );
+	}
+}


### PR DESCRIPTION
## Summary
- Locked wallets were still getting a Via wallet checkout discount when partial payment + auto-deduct were enabled, while the ledger correctly refused the debit — allowing unlimited undercharged orders.
- Gate `is_enable_wallet_partial_payment()` (and Blocks/Store API/AJAX entry points) on `is_wallet_account_locked()` so blocked balances are never treated as spendable.
- Add regression coverage in `tests/test-partial-payment-locked-wallet.php`.

## Test plan
- [ ] Lock a user wallet with balance 700; enable Partial Payment + Auto deduct; place a 900 order — no Via wallet fee, customer pays full 900, balance stays 700
- [ ] Unlock the same wallet and retry — auto-deduct applies 700 and balance drops after order
- [ ] `composer test -- --filter Test_Partial_Payment_Locked_Wallet`
- [ ] Confirm Blocks checkout Apply UI is hidden when wallet is locked

Made with [Cursor](https://cursor.com)