### PR TITLE
fix(partial-payment): stop double wallet refunds on cancel spam

### DIFF
--- a/includes/class-woo-wallet-ajax.php
+++ b/includes/class-woo-wallet-ajax.php
@@ -211,23 +211,70 @@ if ( ! class_exists( 'Woo_Wallet_Ajax' ) ) {
 
 		/**
 		 * Wallet partial payment refund.
+		 *
+		 * Shares the per-order `woo_wallet_refund_partial_<id>` lock with
+		 * cancel / WC refund handlers and claims the refunded marker before
+		 * crediting so double-clicks cannot return the wallet debit twice.
 		 */
 		public function woo_wallet_refund_partial_payment() {
+			global $wpdb;
+
 			if ( ! current_user_can( 'edit_shop_orders' ) ) {
 				wp_die( -1 );
 			}
-			$response               = array( 'success' => false );
-			$order_id               = absint( filter_input( INPUT_POST, 'order_id' ) );
-			$order                  = wc_get_order( $order_id );
-			$partial_payment_amount = get_order_partial_payment_amount( $order_id );
-			$transaction_id         = woo_wallet()->wallet->credit( $order->get_customer_id(), $partial_payment_amount, __( 'Wallet refund #', 'woo-wallet' ) . $order->get_order_number(), array( 'currency' => $order->get_currency( 'edit' ) ) );
-			if ( $transaction_id ) {
-				$response['success'] = true;
-				/* translators: wallet amount */
-				$order->add_order_note( sprintf( __( '%s refunded to customer wallet', 'woo-wallet' ), wc_price( $partial_payment_amount, woo_wallet_wc_price_args( $order->get_customer_id() ) ) ) );
-				WOO_Wallet_Helper::update_order_meta_data( $order, '_woo_wallet_partial_payment_refunded', true, false );
-				WOO_Wallet_Helper::update_order_meta_data( $order, '_partial_payment_refund_id', $transaction_id );
-				do_action( 'woo_wallet_partial_order_refunded', $order_id, $transaction_id );
+			$response = array( 'success' => false );
+			$order_id = absint( filter_input( INPUT_POST, 'order_id' ) );
+			if ( ! $order_id ) {
+				wp_send_json( $response );
+			}
+
+			$lock_name    = 'woo_wallet_refund_partial_' . $order_id;
+			$lock_timeout = (int) apply_filters( 'woo_wallet_db_lock_timeout', 5, $order_id );
+			$got_lock     = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, $lock_timeout ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			if ( '1' !== (string) $got_lock ) {
+				wp_send_json( $response );
+			}
+
+			try {
+				$order = WOO_Wallet_Helper::get_order_for_update( $order_id );
+				if ( ! $order || ! $order->get_meta( '_partial_pay_through_wallet_compleate' ) || $order->get_meta( '_woo_wallet_partial_payment_refunded' ) ) {
+					wp_send_json( $response );
+				}
+
+				$partial_payment_amount = (float) get_order_partial_payment_amount( $order_id );
+				$already_refunded       = (float) $order->get_meta( '_woo_wallet_partial_refunded_total' );
+				$refund_gross           = max( 0.0, $partial_payment_amount - $already_refunded );
+				if ( $refund_gross <= 0 ) {
+					$order->update_meta_data( '_woo_wallet_partial_payment_refunded', true );
+					$order->delete_meta_data( '_partial_pay_through_wallet_compleate' );
+					$order->save();
+					wp_send_json( $response );
+				}
+
+				// Claim before credit — first click wins.
+				$order->update_meta_data( '_woo_wallet_partial_payment_refunded', true );
+				$order->update_meta_data( '_woo_wallet_partial_refunded_total', $already_refunded + $refund_gross );
+				$order->delete_meta_data( '_partial_pay_through_wallet_compleate' );
+				$order->save();
+
+				$transaction_id = woo_wallet()->wallet->credit(
+					$order->get_customer_id(),
+					$refund_gross,
+					__( 'Wallet refund #', 'woo-wallet' ) . $order->get_order_number(),
+					array( 'currency' => $order->get_currency( 'edit' ) )
+				);
+				if ( $transaction_id ) {
+					$response['success'] = true;
+					/* translators: wallet amount */
+					$order->add_order_note( sprintf( __( '%s refunded to customer wallet', 'woo-wallet' ), wc_price( $refund_gross, woo_wallet_wc_price_args( $order->get_customer_id() ) ) ) );
+					WOO_Wallet_Helper::update_order_meta_data( $order, '_partial_payment_refund_id', $transaction_id );
+					do_action( 'woo_wallet_partial_order_refunded', $order_id, $transaction_id );
+				} else {
+					$order->add_order_note( __( 'Wallet partial refund was claimed but the credit failed. Manual review required.', 'woo-wallet' ) );
+					$order->save();
+				}
+			} finally {
+				$wpdb->query( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			}
 			wp_send_json( $response );
 		}

--- a/includes/class-woo-wallet-helper.php
+++ b/includes/class-woo-wallet-helper.php
@@ -32,4 +32,44 @@ class WOO_Wallet_Helper {
 			$order->save();
 		}
 	}
+
+	/**
+	 * Load an order with meta re-read from the datastore.
+	 *
+	 * Drops in-request / object-cache copies first so a concurrent cancel or
+	 * refund that already claimed markers is visible inside a GET_LOCK critical
+	 * section (plain `wc_get_order()` often returns the stale cached instance).
+	 *
+	 * @param int $order_id Order id.
+	 * @return WC_Order|false
+	 */
+	public static function get_order_for_update( $order_id ) {
+		$order_id = absint( $order_id );
+		if ( ! $order_id ) {
+			return false;
+		}
+
+		wp_cache_delete( 'order-' . $order_id, 'orders' );
+		wp_cache_delete( $order_id, 'posts' );
+
+		if ( class_exists( '\Automattic\WooCommerce\Caches\OrderCache' ) && function_exists( 'wc_get_container' ) ) {
+			try {
+				$order_cache = wc_get_container()->get( \Automattic\WooCommerce\Caches\OrderCache::class );
+				if ( $order_cache && is_callable( array( $order_cache, 'remove' ) ) ) {
+					$order_cache->remove( $order_id );
+				}
+			} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				// Container/cache unavailable — fall through to read_meta_data.
+			}
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return false;
+		}
+		if ( is_callable( array( $order, 'read_meta_data' ) ) ) {
+			$order->read_meta_data( true );
+		}
+		return $order;
+	}
 }

--- a/includes/class-woo-wallet-wallet.php
+++ b/includes/class-woo-wallet-wallet.php
@@ -728,7 +728,7 @@ if ( ! class_exists( 'Woo_Wallet_Wallet' ) ) {
 			}
 
 			try {
-				$locked_order = wc_get_order( $order_id );
+				$locked_order = WOO_Wallet_Helper::get_order_for_update( $order_id );
 				if ( ! $locked_order || $locked_order->get_meta( '_woo_wallet_partial_payment_refunded' ) ) {
 					return;
 				}
@@ -761,6 +761,16 @@ if ( ! class_exists( 'Woo_Wallet_Wallet' ) ) {
 					$credit_currency = $locked_order->get_currency( 'edit' );
 				}
 
+				// Claim before credit so a concurrent cancel/refund cannot double-pay.
+				$processed[] = (string) $refund_id;
+				$new_total   = $already + $refund_now;
+				$locked_order->update_meta_data( '_woo_wallet_partial_refunded_total', $new_total );
+				$locked_order->update_meta_data( '_woo_wallet_partial_refund_ids', $processed );
+				if ( $new_total + 0.001 >= $via_wallet ) {
+					$locked_order->update_meta_data( '_woo_wallet_partial_payment_refunded', true );
+				}
+				$locked_order->save();
+
 				$transaction_id = $this->credit(
 					$locked_order->get_customer_id(),
 					$credit_amount,
@@ -774,17 +784,13 @@ if ( ! class_exists( 'Woo_Wallet_Wallet' ) ) {
 				);
 
 				if ( $transaction_id ) {
-					$processed[] = (string) $refund_id;
-					$new_total   = $already + $refund_now;
-					WOO_Wallet_Helper::update_order_meta_data( $locked_order, '_woo_wallet_partial_refunded_total', $new_total );
-					WOO_Wallet_Helper::update_order_meta_data( $locked_order, '_woo_wallet_partial_refund_ids', $processed );
 					/* translators: wallet amount */
 					$locked_order->add_order_note( sprintf( __( '%s of the wallet payment refunded to the customer wallet (partial refund).', 'woo-wallet' ), wc_price( $refund_now, woo_wallet_wc_price_args( $locked_order->get_customer_id() ) ) ) );
-					if ( $new_total + 0.001 >= $via_wallet ) {
-						WOO_Wallet_Helper::update_order_meta_data( $locked_order, '_woo_wallet_partial_payment_refunded', true );
-					}
 					$locked_order->save();
 					do_action( 'woo_wallet_partial_payment_refunded', $order_id, $transaction_id, $refund_now );
+				} else {
+					$locked_order->add_order_note( __( 'Wallet partial refund was claimed but the credit failed. Manual review required.', 'woo-wallet' ) );
+					$locked_order->save();
 				}
 			} finally {
 				$wpdb->query( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -824,28 +830,33 @@ if ( ! class_exists( 'Woo_Wallet_Wallet' ) ) {
 			/**
 			 * Credit partial payment amount.
 			 *
-			 * Serialised via the same per-order GET_LOCK used by
-			 * `wallet_credit_purchase` so two concurrent cancel webhooks (or a
-			 * cancel racing with a status-change retry) cannot double-refund.
-			 * The marker meta (`_partial_pay_through_wallet_compleate`) is
-			 * re-read inside the lock so the first holder wins.
+			 * Shares `woo_wallet_refund_partial_<id>` with
+			 * `process_partial_payment_refund` so cancel and WC refund cannot
+			 * race. Claims `_woo_wallet_partial_payment_refunded` before the
+			 * ledger credit, and re-reads order meta via
+			 * `WOO_Wallet_Helper::get_order_for_update()` so a stale WC order
+			 * cache cannot re-admit a second credit after the first holder.
 			 */
 			$partial_payment_amount = get_order_partial_payment_amount( $order_id );
 			if ( $partial_payment_amount ) {
-				$lock_name    = 'woo_wallet_cancel_partial_' . absint( $order_id );
+				$lock_name    = 'woo_wallet_refund_partial_' . absint( $order_id );
 				$lock_timeout = (int) apply_filters( 'woo_wallet_db_lock_timeout', 5, $order_id );
 				$got_lock     = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, $lock_timeout ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 				if ( '1' === (string) $got_lock ) {
 					try {
-						// Re-fetch the order inside the lock so the marker
-						// read reflects any concurrent delete that landed
-						// while we were waiting on the lock.
-						$locked_order = wc_get_order( $order_id );
+						$locked_order = WOO_Wallet_Helper::get_order_for_update( $order_id );
 						if ( $locked_order && $locked_order->get_meta( '_partial_pay_through_wallet_compleate' ) && ! $locked_order->get_meta( '_woo_wallet_partial_payment_refunded' ) ) {
 							// Refund only the portion not already returned by earlier partial refunds.
 							$already_refunded = (float) $locked_order->get_meta( '_woo_wallet_partial_refunded_total' );
 							$refund_gross     = max( 0.0, $partial_payment_amount - $already_refunded );
+
+							// Claim before credit — first holder wins permanently.
+							$locked_order->update_meta_data( '_woo_wallet_partial_payment_refunded', true );
+							$locked_order->update_meta_data( '_woo_wallet_partial_refunded_total', $already_refunded + $refund_gross );
+							$locked_order->delete_meta_data( '_partial_pay_through_wallet_compleate' );
+							$locked_order->save();
+
 							if ( $refund_gross > 0 ) {
 								// FX-stable: reverse the stored base amount proportionally when present.
 								$base_amount   = (float) $locked_order->get_meta( '_partial_payment_base_amount' );
@@ -858,7 +869,7 @@ if ( ! class_exists( 'Woo_Wallet_Wallet' ) ) {
 									$credit_currency = $locked_order->get_currency( 'edit' );
 								}
 								/* translators: Order number */
-								$this->credit(
+								$transaction_id = $this->credit(
 									$locked_order->get_customer_id(),
 									$credit_amount,
 									sprintf( __( 'Your order with ID #%s has been cancelled and hence your wallet amount has been refunded!', 'woo-wallet' ), $locked_order->get_order_number() ),
@@ -868,12 +879,14 @@ if ( ! class_exists( 'Woo_Wallet_Wallet' ) ) {
 										'order_id' => $order->get_order_number(),
 									)
 								);
-								/* translators: wallet amount */
-								$locked_order->add_order_note( sprintf( __( 'Wallet amount %s has been credited to customer upon cancellation', 'woo-wallet' ), wc_price( $refund_gross, woo_wallet_wc_price_args( $locked_order->get_customer_id() ) ) ) );
+								if ( $transaction_id ) {
+									/* translators: wallet amount */
+									$locked_order->add_order_note( sprintf( __( 'Wallet amount %s has been credited to customer upon cancellation', 'woo-wallet' ), wc_price( $refund_gross, woo_wallet_wc_price_args( $locked_order->get_customer_id() ) ) ) );
+								} else {
+									$locked_order->add_order_note( __( 'Wallet cancellation refund was claimed but the credit failed. Manual review required.', 'woo-wallet' ) );
+								}
+								$locked_order->save();
 							}
-							$locked_order->delete_meta_data( '_partial_pay_through_wallet_compleate' );
-							$locked_order->save();
-							WOO_Wallet_Helper::update_order_meta_data( $locked_order, '_woo_wallet_partial_payment_refunded', true );
 							$order = $locked_order;
 						}
 					} finally {

--- a/tests/test-partial-payment-refund.php
+++ b/tests/test-partial-payment-refund.php
@@ -166,6 +166,53 @@ class Test_Partial_Payment_Refund extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Spam-cancel / double cancel credits the wallet debit only once.
+	 */
+	public function test_cancel_is_idempotent() {
+		woo_wallet()->wallet->credit( $this->user_id, 200, 'seed' );
+		$order = $this->make_order( 100, 0, 100 );
+		$this->debit_order( $order ); // balance 100.
+
+		woo_wallet()->wallet->process_cancelled_order( $order->get_id() );
+		woo_wallet()->wallet->process_cancelled_order( $order->get_id() );
+
+		$this->assertEquals( 200.0, $this->balance() ); // +100 once, not twice.
+		$fresh = WOO_Wallet_Helper::get_order_for_update( $order->get_id() );
+		$this->assertNotEmpty( $fresh->get_meta( '_woo_wallet_partial_payment_refunded' ) );
+		$this->assertEmpty( $fresh->get_meta( '_partial_pay_through_wallet_compleate' ) );
+	}
+
+	/**
+	 * A stale in-request order cache must not allow a second cancel credit
+	 * after another holder already claimed the refund marker.
+	 */
+	public function test_cancel_after_stale_order_cache() {
+		woo_wallet()->wallet->credit( $this->user_id, 200, 'seed' );
+		$order = $this->make_order( 100, 0, 100 );
+		$this->debit_order( $order ); // balance 100.
+
+		// Simulate request B holding a stale copy that still shows the debit marker.
+		$stale = wc_get_order( $order->get_id() );
+		$this->assertNotEmpty( $stale->get_meta( '_partial_pay_through_wallet_compleate' ) );
+
+		// Concurrent winner claims via a fresh write path.
+		$winner = WOO_Wallet_Helper::get_order_for_update( $order->get_id() );
+		$winner->update_meta_data( '_woo_wallet_partial_payment_refunded', true );
+		$winner->update_meta_data( '_woo_wallet_partial_refunded_total', 100 );
+		$winner->delete_meta_data( '_partial_pay_through_wallet_compleate' );
+		$winner->save();
+		woo_wallet()->wallet->credit( $this->user_id, 100, 'winner cancel refund' ); // balance 200.
+
+		// Stale handle still looks unrefunded — cancel must re-read and skip.
+		$this->assertNotEmpty( $stale->get_meta( '_partial_pay_through_wallet_compleate' ) );
+		$this->assertEmpty( $stale->get_meta( '_woo_wallet_partial_payment_refunded' ) );
+
+		woo_wallet()->wallet->process_cancelled_order( $order->get_id() );
+
+		$this->assertEquals( 200.0, $this->balance() ); // no second +100.
+	}
+
+	/**
 	 * A taxable fee's gross (base + tax) is the amount debited.
 	 */
 	public function test_tax_inclusive_gross_is_debited() {


### PR DESCRIPTION
## Summary
- Spam-cancelling an order with a wallet partial payment could credit the debit multiple times because cancel used a separate lock, re-read a stale `wc_get_order()` cache, and wrote the refunded marker only after `credit()`.
- Claim `_woo_wallet_partial_payment_refunded` before the ledger credit, share `woo_wallet_refund_partial_<id>` across cancel / WC refund / admin AJAX, and load orders via `WOO_Wallet_Helper::get_order_for_update()`.
- Add regression tests for idempotent cancel and stale-cache protection.

## Test plan
- [ ] Place an order with partial payment, spam Cancel from My Account — wallet credited once only
- [ ] Cancel after a partial WC refund — only the remainder returns
- [ ] Double-click admin `Refund` on the Via wallet fee — credited once
- [ ] `composer test -- --filter Test_Partial_Payment_Refund`